### PR TITLE
Remove certificates from keychain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ before_script:
   - wget -O ./Recommend-It/APIKeys.plist $API_KEYS_PATH
   - openssl aes-256-cbc -k "$ENCRYPTION_SECRET_PROVISIONING_PROFILE" -in CI/profile/XC_iOS_comderrickshowersRecommendIt.mobileprovision.enc -d -a -out CI/profile/XC_iOS_comderrickshowersRecommendIt.mobileprovision
   - openssl aes-256-cbc -k "$ENCRYPTION_SECRET_PROVISIONING_PROFILE" -in CI/profile/XC_iOS_comderrickshowersRecommendIt_Team.mobileprovision.enc -d -a -out CI/profile/XC_iOS_comderrickshowersRecommendIt_Team.mobileprovision
-  - openssl aes-256-cbc -k "$ENCRYPTION_SECRET" -in CI/certs/development.cer.enc -d -a -out CI/certs/development.cer
-  - openssl aes-256-cbc -k "$ENCRYPTION_SECRET" -in CI/certs/distribution.cer.enc -d -a -out CI/certs/distribution.cer
   - openssl aes-256-cbc -k "$ENCRYPTION_SECRET" -in CI/certs/development.p12.enc -d -a -out CI/certs/development.p12
   - openssl aes-256-cbc -k "$ENCRYPTION_SECRET" -in CI/certs/distribution.p12.enc -d -a -out CI/certs/distribution.p12
   - ./CI/add-key.sh

--- a/CI/add-key.sh
+++ b/CI/add-key.sh
@@ -16,8 +16,6 @@ security unlock-keychain -p travis $KEY_CHAIN
 security set-keychain-settings -t 3600 -u $KEY_CHAIN
 
 # Add certificates to keychain and allow codesign to access them
-security import ./CI/certs/development.cer -k $KEY_CHAIN -A /usr/bin/codesign
-security import ./CI/certs/distribution.cer -k $KEY_CHAIN -A /usr/bin/codesign
 security import ./CI/certs/development.p12 -k $KEY_CHAIN -P $KEY_PASSWORD -T /usr/bin/codesign
 security import ./CI/certs/distribution.p12 -k $KEY_CHAIN -P $KEY_PASSWORD -T /usr/bin/codesign
 


### PR DESCRIPTION
I don't think we need to copy certificates to the keychain on Travis because they should be part of the .p12 files. Let's see...